### PR TITLE
Upgrade package to Filament 5.x compatibility

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -36,7 +36,7 @@ body:
     attributes:
       label: PHP Version
       description: What version of PHP are you running? Please be as specific as possible
-      placeholder: 8.2.0
+      placeholder: 8.3.0
     validations:
       required: true
   - type: input

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,14 +13,19 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, windows-latest]
-        php: [8.4, 8.3, 8.2]
-        laravel: [12.*, 11.*]
+        php: [8.5, 8.4, 8.3]
+        laravel: [13.*, 12.*, 11.*]
         stability: [prefer-lowest, prefer-stable]
         include:
           - laravel: 11.*
-            testbench: ^9.5
+            testbench: ~9.5
           - laravel: 12.*
             testbench: 10.*
+          - laravel: 13.*
+            testbench: 11.*
+        exclude:
+          - laravel: 11.*
+            php: 8.5
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 
@@ -33,7 +38,7 @@ jobs:
         with:
           php-version: ${{ matrix.php }}
           extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick, fileinfo
-          coverage: none
+          coverage: xdebug
 
       - name: Setup problem matchers
         run: |

--- a/composer.json
+++ b/composer.json
@@ -27,8 +27,8 @@
     ],
     "require": {
         "php": "^8.2",
-        "filament/filament": "^4.0",
-        "filament/forms": "^4.0",
+        "filament/filament": "^4.0|^5.0",
+        "filament/forms": "^4.0|^5.0",
         "spatie/laravel-package-tools": "^1.16"
     },
     "require-dev": {
@@ -36,11 +36,11 @@
         "laravel/pint": "^1.14",
         "matanyadaev/laravel-eloquent-spatial": "^4.5",
         "nunomaduro/collision": "^8.1",
-        "orchestra/testbench": "^9.0|^10.0",
-        "pestphp/pest": "^3.0",
-        "pestphp/pest-plugin-arch": "^3.0",
-        "pestphp/pest-plugin-laravel": "^3.0",
-        "pestphp/pest-plugin-livewire": "^3.0",
+        "orchestra/testbench": "^9.0|^10.0|^11.0",
+        "pestphp/pest": "^4.0",
+        "pestphp/pest-plugin-arch": "^4.0",
+        "pestphp/pest-plugin-laravel": "^4.0",
+        "pestphp/pest-plugin-livewire": "^4.0",
         "phpstan/extension-installer": "^1.3",
         "phpstan/phpstan-deprecation-rules": "^2.0",
         "phpstan/phpstan-phpunit": "^2.0"


### PR DESCRIPTION
This PR upgrades the swisnl/filament-geometry package to be compatible with Filament 5.x, addressing the requirement to modernize the package for the latest Filament version.